### PR TITLE
feat: display latest git SHA in the footer (alongside version)

### DIFF
--- a/public/swagger.yml
+++ b/public/swagger.yml
@@ -90,7 +90,12 @@ paths:
         '200':
           description: OK
           schema:
-            type: string
+            type: object
+            properties:
+              version:
+                type: string
+              hash:
+                type: string
         '404':
           description: Not found
   /authenticate:

--- a/src/common/layout/footer.css
+++ b/src/common/layout/footer.css
@@ -18,3 +18,8 @@ footer {
    height: 10vh;
    display: block;
 }
+
+#version-hash-link {
+   text-decoration: none;
+   margin-left: 1vw;
+}

--- a/src/common/layout/footer.tsx
+++ b/src/common/layout/footer.tsx
@@ -4,26 +4,37 @@ import Container from "react-bootstrap/Container";
 
 import './footer.css';
 import {useSelector} from "react-redux";
+import {colors} from "../../App";
 
 function Footer() {
     const darkThemeEnabled = useSelector((state: any) => state.preferences.darkThemeEnabled);
 
     const [version, setVersion] = useState('');
+    const [hash, setHash] = useState('');
 
      useEffect(() => {
-        V1.SystemService.getVersion().then((v: string) => {
-            setVersion(v);
+        V1.SystemService.getVersion().then((v: { version?: string; hash?: string; }) => {
+            v.version && setVersion(v.version);
+            v.hash && setHash(v.hash);
         }).catch(reason => console.error("Failed to fetch version: ", reason));
     }, [])
+
+    const color = darkThemeEnabled ? colors.textColor.dark : colors.textColor.light;
 
     return (
         <footer className="footer mt-auto padded text-center" style={{
             backgroundColor: darkThemeEnabled ? '#283845' : '#fff'
         }}>
             <Container fluid={true}>
-                <span style={{ color: darkThemeEnabled ? '#bbb' : '#475362' }}>
-                    {version || 'No version data'}
-                </span>
+                <span>{version || 'No version data'}</span>
+                {
+                    hash && <small>
+                        <a id={'version-hash-link'} style={{color}}
+                           href={'https://github.com/nds-org/workbench-apiserver-python/tree/'+hash}>
+                            {hash.substr(0,8)}
+                        </a>
+                    </small>
+                }
             </Container>
         </footer>
     );

--- a/src/common/services/openapi/v1/services/SystemService.ts
+++ b/src/common/services/openapi/v1/services/SystemService.ts
@@ -8,10 +8,13 @@ export class SystemService {
     /**
      * Retrieve the server version from the Swagger spec
      *
-     * @returns string OK
+     * @returns any OK
      * @throws ApiError
      */
-    public static async getVersion(): Promise<string> {
+    public static async getVersion(): Promise<{
+        version?: string,
+        hash?: string,
+    }> {
         const result = await __request({
             method: 'GET',
             path: `/version`,


### PR DESCRIPTION
## Problem
Version number displayed in footer does not give enough information about the version

## Approach
* Include `hash` here, link to GitHub commit using the hash