### PR TITLE
Revert "chore: remove livereload Dockerfile (not needed)"

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,11 @@
+FROM node:14
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+COPY . .
+RUN yarn swagger
+
+EXPOSE 3000
+EXPOSE 9222
+CMD ["yarn", "run", "start:remote"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Labs Workbench WebUI 2.x
 
-Running instances of etcd + apiserver are required.
+Running instances of mongodb + apiserver are required.
 
 ## Kubernetes
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Labs Workbench WebUI 2.x
 
-Running instances of mongodb + apiserver are required.
+Running instances of etcd + apiserver are required.
 
 ## Kubernetes
 
@@ -21,13 +21,13 @@ To customize the installation, see the Configuration section of the [Helm chart]
 To mount the webui compiled source into a webui dev container:
 ```bash
 $ make dev
-# OR
-$ make local
 ```
 
 You can then re-compile the source using `yarn build`.
 
 Once compilation has finished, your browser window should automatically refresh.
+
+NOTE: Unfortunately, CRA doesn't provide a `/build` output folder while also watching for changes (a la `ng build --watch`), so true live-reload is not yet feasible. This would require an `eject` and for us to build up more tooling here for the build.
 
 ## Docker Compose (Development Only)
 


### PR DESCRIPTION
## Problem
We may need this after all :)

See https://github.com/nds-org/workbench-helm-chart/pull/38

`make local` does not recompile the webui source without running `make compile` every time..

Since `make compile` runs the prod build, this takes 30+ seconds for every change (compared the `make dev` development build which is nearly instantaneous)

## Approach
Reverts nds-org/workbench-webui#3