### PR TITLE
feat: my-catalog and add-edit-spec pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,8 @@ import {setEnv} from "./store/actions";
 import ReactGA from "react-ga";
 import {V1, V2} from "./common";
 import EditServicePage from "./views/my-apps/EditService";
+import MyCatalogPage from "./views/my-catalog/MyCatalog";
+import AddEditSpecPage from "./views/my-catalog/AddEditSpec";
 
 export const colors = {
     backgroundColor: { light: "#FBFBFB", dark: "#475362" },
@@ -99,6 +101,15 @@ function App() {
                             </Route>
                             <Route exact path="/all-apps">
                                 <AllAppsPage />
+                            </Route>
+                            <Route exact path="/my-catalog">
+                                <MyCatalogPage />
+                            </Route>
+                            <Route exact path="/my-catalog/create">
+                                <AddEditSpecPage />
+                            </Route>
+                            <Route path="/my-catalog/:specKey">
+                                <AddEditSpecPage />
                             </Route>
                             <Route exact path="/my-apps/:stackId/edit">
                                 <EditServicePage />

--- a/src/common/layout/header.tsx
+++ b/src/common/layout/header.tsx
@@ -87,10 +87,10 @@ function Header() {
 
     const activeColor = darkThemeEnabled ? 'white' : '#283845';
     const css = `
-    .navbar-light {
+    #navbar.navbar-light {
         box-shadow: 0 2px 3px darkgrey;
     }
-    .nav-link.active {
+    #navbar .nav-link.active {
         border-bottom: ${activeColor} 8px solid;
         margin-bottom: -10px;
     }
@@ -103,7 +103,7 @@ function Header() {
     return (
         <>
             <style>{css}</style>
-            <Navbar expand="lg" variant={darkThemeEnabled ? 'dark' : 'light'} style={{ paddingLeft: "20px", paddingRight: "20px", backgroundColor: darkThemeEnabled ? '#283845' : '#fff', color: darkThemeEnabled ? '#fff' : '#283845' }}>
+            <Navbar id={'navbar'} expand="lg" variant={darkThemeEnabled ? 'dark' : 'light'} style={{ paddingLeft: "20px", paddingRight: "20px", backgroundColor: darkThemeEnabled ? '#283845' : '#fff', color: darkThemeEnabled ? '#fff' : '#283845' }}>
                 <LinkContainer key="ROOT" to="/">
                     <Navbar.Brand title='Workbench'>
                         <img alt={'favicon'} width="32" height="32" src={ env?.customization?.favicon_path || '/favicon.svg' } /> { env?.customization?.product_name }

--- a/src/common/layout/header.tsx
+++ b/src/common/layout/header.tsx
@@ -119,6 +119,13 @@ function Header() {
                             <LinkContainer key='my-apps' to='/my-apps'>
                                 <Nav.Link>My Apps</Nav.Link>
                             </LinkContainer>
+                            {
+                                (user?.groups?.includes('/workbench-developers') || user?.groups?.includes('/workbench-admin')) && <>
+                                    <LinkContainer key='my-catalog' to='/my-catalog'>
+                                        <Nav.Link>My Catalog</Nav.Link>
+                                    </LinkContainer>
+                                </>
+                            }
                         </Nav>
                     }
                     <Nav className="ms-auto" activeKey="">

--- a/src/index.css
+++ b/src/index.css
@@ -16,3 +16,10 @@ code {
 #root, #root > div {
   min-height: 100vh;
 }
+
+.pull-right {
+  float: right;
+}
+.pull-left {
+  float: left;
+}

--- a/src/views/all-apps/SpecView.tsx
+++ b/src/views/all-apps/SpecView.tsx
@@ -98,7 +98,7 @@ function SpecView() {
                                 <Col>
                                     <Row>
                                         <Col style={{ textAlign: "left" }}>
-                                            <h1>{spec?.label || spec?.key}</h1>
+                                            <h2>{spec?.label || spec?.key}</h2>
                                             <small>ID: {spec.key}</small>
                                         </Col>
                                         <Col sm={2}>

--- a/src/views/my-apps/EditService.tsx
+++ b/src/views/my-apps/EditService.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import Container from "react-bootstrap/Container";
 import {Redirect, useParams} from 'react-router-dom';
 import {useSelector} from "react-redux";
@@ -9,6 +9,7 @@ import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faCaretLeft, faPlus, faSave} from "@fortawesome/free-solid-svg-icons";
 import {V1} from "../../common";
 import {faSpinner} from "@fortawesome/free-solid-svg-icons/faSpinner";
+import {faTimes} from "@fortawesome/free-solid-svg-icons/faTimes";
 
 interface EnvVar {
     name: string;
@@ -102,7 +103,7 @@ function EditServicePage(props: {}) {
     }
 
     const handleChange = (event: any, serviceKey: string, envIndex: number, field: string = 'name') => {
-        console.log("Handling change to target: ", );
+        console.log("Handling change to target: ", event);
         const envVars = vars;
         const svcEnv = vars.find(s => s.service === serviceKey);
         if (!svcEnv) {
@@ -115,6 +116,10 @@ function EditServicePage(props: {}) {
         envVars[index] = svcEnv;
         setVars([...envVars]);
     };
+
+    const cancel = () => {
+        setRedirect('/my-apps');
+    }
 
     const save = () => {
         setSaving(true);
@@ -207,7 +212,6 @@ function EditServicePage(props: {}) {
                                         </Form>
 
                                         <Button onClick={() => addVar(svc.service)}><FontAwesomeIcon icon={faPlus} /></Button>
-                                        <Button disabled={disabled()} className={'btn-success'} onClick={save}><FontAwesomeIcon className={saving ? 'fa-spin' : ''} icon={saving ? faSpinner : faSave} /></Button>
                                     </Tab.Pane>
                                 </Tab.Content>
                             </Col>
@@ -216,6 +220,16 @@ function EditServicePage(props: {}) {
                 </Tab>)
             }
         </Tabs>
+
+
+        <div className={'pull-right'}>
+            <Button className={'btn-lg btn-secondary'} onClick={cancel}>
+                <FontAwesomeIcon icon={faTimes} /> Cancel
+            </Button>
+            <Button disabled={disabled()} className={'btn-lg btn-success'} onClick={save}>
+                <FontAwesomeIcon className={saving ? 'fa-spin' : ''} icon={saving ? faSpinner : faSave} /> Save
+            </Button>
+        </div>
     </Container>
 }
 

--- a/src/views/my-apps/MyApps.tsx
+++ b/src/views/my-apps/MyApps.tsx
@@ -31,6 +31,7 @@ import {Redirect} from "react-router-dom";
 import {colors} from "../../App";
 import ReactGA from "react-ga";
 
+import './MyApps.css';
 
 const navigate = (stk: V1.Stack, ep: any) => {
     window.open(`${ep.protocol}://${ep.host}`, '_blank');

--- a/src/views/my-catalog/AddEditSpec.css
+++ b/src/views/my-catalog/AddEditSpec.css
@@ -1,13 +1,17 @@
 
-.tab-content {
-    margin-top: 5vh;
-}
-
 .text-align-left {
     text-align: left;
 }
 .text-align-right {
     text-align: right;
+}
+
+#showJsonCard {
+    margin: 25px;
+}
+
+#showJsonCard pre {
+    padding: 25px;
 }
 
 .marginTop {

--- a/src/views/my-catalog/AddEditSpec.css
+++ b/src/views/my-catalog/AddEditSpec.css
@@ -1,0 +1,22 @@
+
+.tab-content {
+    margin-top: 5vh;
+}
+
+.text-align-left {
+    text-align: left;
+}
+.text-align-right {
+    text-align: right;
+}
+
+.marginTop {
+    margin-top: 5vh;
+}
+.marginLeft {
+    margin-left: 5vh;
+}
+
+.text-red {
+    color: red;
+}

--- a/src/views/my-catalog/AddEditSpec.tsx
+++ b/src/views/my-catalog/AddEditSpec.tsx
@@ -1,0 +1,608 @@
+import React, {useEffect, useState} from 'react';
+import '../../index.css';
+import Button from "react-bootstrap/Button";
+import Container from "react-bootstrap/Container";
+import Table from "react-bootstrap/Table";
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {V1, handleError} from "../../common";
+
+import {faTrash} from "@fortawesome/free-solid-svg-icons/faTrash";
+import {faTimes} from "@fortawesome/free-solid-svg-icons/faTimes";
+import {faSave} from "@fortawesome/free-solid-svg-icons/faSave";
+
+import {useSelector} from "react-redux";
+import {Redirect, useParams} from "react-router-dom";
+import ReactGA from "react-ga";
+
+import './AddEditSpec.css';
+import Form from "react-bootstrap/Form";
+import {FormControl, Tab, Tabs} from "react-bootstrap";
+import {faPlus} from "@fortawesome/free-solid-svg-icons";
+import Col from "react-bootstrap/Col";
+import Row from "react-bootstrap/Row";
+import FormGroup from "react-bootstrap/FormGroup";
+
+const sortBy = (s1: V1.Service, s2: V1.Service) => {
+    const sid1 = s1.label+"";
+    const sid2 = s2.label+""
+    if (sid1 > sid2) {
+        return 1;
+    } else if (sid1 < sid2) {
+        return -1;
+    } else {
+        return 0;
+    }
+}
+
+const AddEditSpecPage = (props: any) => {
+    // Global state
+    const darkThemeEnabled = useSelector((state: any) => state.preferences.darkThemeEnabled);
+    const env = useSelector((state: any) => state.env);
+    const user = useSelector((state: any) => state.auth.user);
+
+    // Query params
+    const {specKey} = useParams<{ specKey?: string; }>();
+
+    // Server data
+    const [stacks, setStacks] = useState<Array<V1.Stack>>([]);
+    const [specs, setSpecs] = useState<Array<V1.Service>>([]);
+    const [spec, setSpec] = useState<V1.Service>({
+        // Basic Info
+        key: '',
+        label: '',
+
+        // Access Info
+        display: 'standalone',
+        access: 'external',
+
+        // Docker info
+        image: {
+            name: '',
+            tags: []
+        },
+
+        // Help Info
+        logo: '',
+        info: '',
+
+        // Tabbed info
+        depends: [],
+        config: [],
+        ports: [],
+        volumeMounts: [],
+
+        // TODO: no UI for these yet (advanced features)
+        additionalResources: [],
+        developerEnvironment: undefined,
+        repositories: [],
+        command: [],
+        args: [],
+        catalog: 'user',
+        tags: []
+    });
+
+    // User selection
+    const [selectedTab, setSelectedTab] = useState('Basic Info');
+    const [redirect, setRedirect] = useState<string>('');
+
+    useEffect(() => {
+        if (env?.customization?.product_name) {
+            document.title = `${env?.customization?.product_name}: My Catalog`;
+        }
+    }, [env]);
+
+    useEffect(() => {
+        if (env?.analytics_tracking_id) {
+            ReactGA.pageview('/my-catalog');
+        }
+    }, [env?.analytics_tracking_id]);
+
+    useEffect(() => {
+        if (!Object.keys(env).length) return;
+        V1.AppSpecService.listServicesAll().then(specs => {
+            setSpecs(specs.sort(sortBy));
+            if (specKey) {
+                const spec = specs.find(s => s.key === specKey)
+                if (spec) {
+                    setSpec(spec);
+                }
+            }
+        }).catch(reason => handleError('Failed to fetch specs: ', reason));
+        V1.UserAppService.listUserapps().then(stacks => setStacks(stacks)).catch(reason => handleError('Failed to fetch stacks: ', reason));
+    }, [env]);
+
+    /** Basic Info tab functions */
+    const handleFieldChange = (event: any, field: string) => {
+        console.log("Handling change to field: ", field);
+        if (field === 'imageName') {
+            spec.image.name = event.target.value;
+        } else {
+            // @ts-ignore
+            spec[field] = event.target.value;
+        }
+
+        setSpec({...spec});
+    }
+
+    const handleTagChange = (event: any, tagIndex: number) => {
+        console.log("Handling change to tag: ", event);
+        spec.image.tags[tagIndex] = event.target.value;
+        setSpec({...spec});
+    };
+
+    const addTag = () => {
+        const tags = spec.image.tags || [];
+        tags.push('');
+        spec.image.tags = tags;
+        setSpec({...spec});
+    }
+
+    const removeTag = (tagIndex: number) => {
+        console.log("Removing tag: ", tagIndex);
+        spec.image.tags.splice(tagIndex, 1);
+        setSpec({...spec});
+    }
+
+    /** Dependencies tab functions */
+    const handleDepChange = (event: any, depIndex: number, field: string) => {
+        console.log("Handling change to dependency: ", depIndex);
+        const dep: V1.ServiceDependency = spec.depends[depIndex];
+        if (field === 'required') {
+            dep.required = !dep.required;
+        } else {
+            // @ts-ignore
+            dep[field] = event.target.value;
+        }
+        spec.depends[depIndex] = dep;
+        setSpec({...spec});
+    }
+
+    const removeDependency = (depIndex: number) => {
+        console.log("Removing dependency: ", depIndex);
+        spec.depends.splice(depIndex, 1);
+        setSpec({...spec});
+    }
+
+    const addDependency = () => {
+        const newDep: V1.ServiceDependency = {
+            key: '',
+            required: false
+        };
+        console.log("Adding dependency: ", newDep);
+        spec.depends.push(newDep);
+        setSpec({...spec});
+    }
+
+    /** Environments tab functions */
+
+    const handleEnvChange = (event: any, envIndex: number, field: string) => {
+        console.log("Handling change to env: ", event);
+        const config: V1.Config = spec.config[envIndex];
+        if (field === 'isPassword') {
+            config.isPassword = !config.isPassword;
+        } else if (field === 'canOverride') {
+            config.canOverride = !config.canOverride;
+        } else {
+            // @ts-ignore
+            config[field] = event.target.value;
+        }
+        spec.config[envIndex] = config;
+        setSpec({...spec});
+    };
+
+    const removeEnv = (envIndex: number) => {
+        console.log("Removing env: ", envIndex);
+        spec.config.splice(envIndex, 1);
+        setSpec({...spec});
+    }
+
+    const addEnv = () => {
+        const newEnv: V1.Config = {
+            name: '',
+            value: '',
+            label: '',
+            isPassword: false,
+            canOverride: false
+        };
+        console.log("Adding env: ", newEnv);
+        spec.config.push(newEnv);
+        setSpec({...spec});
+    }
+
+    /** Ports tab functions */
+    const handlePortChange = (event: any, portIndex: number, field: string) => {
+        console.log("Handling change to port: ", event);
+        const port: V1.Port = spec.ports[portIndex];
+        // @ts-ignore
+        port[field] = event.target.value;
+        spec.ports[portIndex] = port;
+        setSpec({...spec});
+    };
+    const removePort = (portIndex: number) => {
+        console.log("Removing port: ", portIndex);
+        spec.ports.splice(portIndex, 1);
+        setSpec({...spec});
+    }
+
+    const addPort = () => {
+        const newPort: V1.Port = {
+            protocol: 'http',
+            port: 80,
+            contextPath: '',
+        };
+        console.log("Adding port: ", newPort);
+        spec.ports.push(newPort);
+        setSpec({...spec});
+    }
+
+
+    /** Volumes tab functions */
+
+    const handleVolChange = (event: any, volIndex: number, field: string) => {
+        console.log("Handling change to volume: ", event);
+        const volume: V1.VolumeMount = spec.volumeMounts[volIndex];
+        // @ts-ignore
+        volume[field] = event.target.value;
+        spec.volumeMounts[volIndex] = volume;
+        setSpec({...spec});
+    };
+    const removeVolume = (volIndex: number) => {
+        console.log("Removing volume: ", volIndex);
+        spec.volumeMounts.splice(volIndex, 1);
+        setSpec({...spec});
+    }
+
+    const addVolume = () => {
+        const newVolume: V1.VolumeMount = {
+            mountPath: '',
+            defaultPath: '',
+        };
+        console.log("Adding volume: ", newVolume);
+        spec.volumeMounts.push(newVolume);
+        setSpec({...spec});
+    }
+
+    /** Button bar functions */
+
+    const cancelSave = (spec: V1.Service) => {
+        setRedirect('/my-catalog');
+    }
+
+    const saveSpec = (spec: V1.Service) => {
+        if (spec.catalog === 'system' && !user?.groups?.includes('/workbench-admin')) {
+            // User is not an admin
+            return;
+        }
+
+        if (specKey) {
+            V1.AppSpecService.updateService(spec.key, spec).then((updated: V1.Service) => {
+                setRedirect('/my-catalog')
+            });
+        } else {
+            V1.AppSpecService.createService(spec).then((created: V1.Service) => {
+                setRedirect('/my-catalog')
+            });
+        }
+    }
+
+    return (
+        <Container fluid={false}>
+            {
+                redirect && <Redirect to={redirect} />
+            }
+            <div style={{ height: "10vh" }}></div>
+            <Row>
+                <Col className={'text-align-left'}>
+                    <h2>{specKey ? 'Edit Application: ' + specKey : 'Create New Application'}</h2>
+                </Col>
+                <Col className={'text-align-right'}>
+                    <Button className={'btn-lg btn-secondary'} onClick={() => cancelSave(spec)}>
+                        <FontAwesomeIcon icon={faTimes} /> Cancel
+                    </Button>
+                    <Button disabled={!spec.key || !spec.image.name || !(spec.image.tags.length && spec.image.tags[0])} className={'btn-lg btn-success'} onClick={() => saveSpec(spec)}>
+                        <FontAwesomeIcon icon={faSave} /> Save
+                    </Button>
+                </Col>
+            </Row>
+            <Row>
+                <Col>
+                    <Form>
+                        <Tabs id={'outerTabBar'} activeKey={selectedTab} onSelect={(e: any) => e && setSelectedTab(e)} fill>
+                            <Tab title={'Basic Info'} key={'Basic Info'} eventKey={'Basic Info'}>
+                                <Row>
+                                    <Col className={'text-align-left marginTop'}>
+                                        <h3>Basic Info</h3>
+                                        <FormGroup>
+                                            <Form.Label>Key<span className={'text-red'}>*</span></Form.Label>
+                                            <FormControl required value={spec.key} onChange={(e) => handleFieldChange(e, 'key')}></FormControl>
+                                        </FormGroup>
+                                        <FormGroup>
+                                            <Form.Label>Label</Form.Label>
+                                            <FormControl value={spec.label} onChange={(e) => handleFieldChange(e, 'label')}></FormControl>
+                                        </FormGroup>
+                                    </Col>
+                                    <Col className={'text-align-left marginTop'}>
+                                        <h3>Docker Info</h3>
+                                        <FormGroup>
+                                            <Form.Label>Image Name<span className={'text-red'}>*</span></Form.Label>
+                                            <Form.Control required value={spec.image.name} onChange={(e) => handleFieldChange(e, 'imageName')}></Form.Control>
+                                        </FormGroup>
+                                        <FormGroup>
+                                            <Form.Label>Tags<span className={'text-red'}>*</span></Form.Label>
+                                            <Table>
+                                                <tbody>
+                                                {
+                                                    spec?.image?.tags?.map((tag, tagIndex) => <tr>
+                                                        <td width='5%'>
+                                                            <Button className={'btn-secondary btn-sm'} onClick={() => removeTag(tagIndex)}><FontAwesomeIcon icon={faTrash} /></Button>
+                                                        </td>
+                                                        <td>
+                                                            <FormControl required value={tag} onChange={(e) => handleTagChange(e, tagIndex)}></FormControl>
+                                                        </td>
+                                                    </tr>)
+                                                }
+                                                <tr>
+                                                    <td>
+                                                        <Button className={'btn-secondary btn-sm marginLeft'} onClick={() => addTag()}>
+                                                            <FontAwesomeIcon icon={faPlus} />
+                                                        </Button>
+                                                    </td>
+                                                    <td></td>
+                                                </tr>
+                                                </tbody>
+                                            </Table>
+                                        </FormGroup>
+                                    </Col>
+                                </Row>
+                                <hr/>
+                                <Row>
+                                    <Col className={'text-align-left marginTop'}>
+                                        <h3>Access Info</h3>
+                                        <FormGroup>
+                                            <Form.Label>Display on All Apps?</Form.Label>
+                                            <Form.Control as="select" defaultValue="stack" onChange={(e) => handleFieldChange(e, 'display')}>
+                                                <option value={'stack'}>Display in All Apps page</option>
+                                                <option value={'standalone'}>Do not display in All Apps page</option>
+                                            </Form.Control>
+                                        </FormGroup>
+                                        <FormGroup>
+                                            <Form.Label>Access</Form.Label>
+                                            <Form.Control as="select" defaultValue="external" onChange={(e) => handleFieldChange(e, 'access')}>
+                                                <option value={'external'}>External (ingress + service)</option>
+                                                <option value={'internal'}>Internal (service only)</option>
+                                                <option value={'none'}>None</option>
+                                            </Form.Control>
+                                        </FormGroup>
+                                    </Col>
+                                    <Col className={'text-align-left marginTop'}>
+                                        <h3>Help Info</h3>
+                                        <FormGroup>
+                                            <Form.Label>Logo (optional)</Form.Label>
+                                            <FormControl value={spec.logo} onChange={(e) => handleFieldChange(e, 'logo')}></FormControl>
+                                        </FormGroup>
+                                        <FormGroup>
+                                            <Form.Label>Info URL (optional)</Form.Label>
+                                            <FormControl value={spec.info} onChange={(e) => handleFieldChange(e, 'info')}></FormControl>
+                                        </FormGroup>
+                                    </Col>
+                                </Row>
+                            </Tab>
+                            <Tab title={'Dependencies'} key={'Dependencies'} eventKey={'Dependencies'}>
+                                <Table size={'sm'}>
+                                    <thead>
+                                    <tr>
+                                        <th></th>
+                                        <th>Service Key</th>
+                                        <th>Required?</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    {
+                                        spec?.depends?.map((dep, depIndex) => <tr key={"dep-"+depIndex}>
+                                            <td>
+                                                <Button className={'btn-secondary btn-sm'} onClick={() => removeDependency(depIndex)}>
+                                                    <FontAwesomeIcon icon={faTrash} />
+                                                </Button>
+                                            </td>
+                                            <td>
+                                                <Form.Group controlId="depKey">
+                                                    <Form.Control as="select" required name={'depKey'} defaultValue="stack" value={dep.key || 'Choose a dependency service'} onChange={(e) => handleDepChange(e, depIndex, 'key')}>
+                                                        {
+                                                            specs.map(spec => <option value={spec.key}>{spec.label} ({spec.key})</option>)
+                                                        }
+                                                    </Form.Control>
+                                                </Form.Group>
+                                            </td>
+                                            <td>
+                                                <Form.Group controlId="depRequired">
+                                                    <Form.Check inline type="checkbox" name={'depRequired'} checked={dep.required} onChange={(e) => handleDepChange(e, depIndex, 'required')} />
+                                                </Form.Group>
+                                            </td>
+                                        </tr>)
+                                    }
+                                    <tr>
+                                        <td>
+                                            <Button className={'btn-primary btn-sm'} onClick={() => addDependency()}>
+                                                <FontAwesomeIcon icon={faPlus} />
+                                            </Button>
+                                        </td>
+                                        <td></td>
+                                        <td></td>
+                                        <td></td>
+                                        <td></td>
+                                        <td></td>
+                                    </tr>
+                                    </tbody>
+                                </Table>
+                            </Tab>
+                            <Tab title={'Environment'} key={'Environment'} eventKey={'Environment'}>
+                                <Table size={'sm'}>
+                                    <thead>
+                                        <tr>
+                                            <th></th>
+                                            <th>Name</th>
+                                            <th>Label</th>
+                                            <th>Value</th>
+                                            <th>Is Password?</th>
+                                            <th>Can Override?</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                    {
+                                        spec?.config?.map((cfg, envIndex) => <tr key={"env-"+envIndex}>
+                                            <td>
+                                                <Button className={'btn-secondary btn-sm'} onClick={() => removeEnv(envIndex)}>
+                                                    <FontAwesomeIcon icon={faTrash} />
+                                                </Button>
+                                            </td>
+                                            <td>
+                                                <Form.Group controlId="envName">
+                                                    <Form.Control required name={'envName'} type="text" placeholder="Name is required" value={cfg.name} onChange={(e) => handleEnvChange(e, envIndex, 'name')} />
+                                                </Form.Group>
+                                            </td>
+                                            <td>
+                                                <Form.Group controlId="envLabel">
+                                                    <Form.Control name={'envLabel'} type="text" placeholder="Enter a label (optional)" value={cfg.label} onChange={(e) => handleEnvChange(e, envIndex, 'label')} />
+                                                </Form.Group>
+                                            </td>
+                                            <td>
+                                                <Form.Group controlId="envVal">
+                                                    <Form.Control type="text" name={'envValue'} placeholder="Enter a value (optional)" value={cfg.value} onChange={(e) => handleEnvChange(e, envIndex, 'value')} />
+                                                </Form.Group>
+                                            </td>
+                                            <td>
+                                                <Form.Group controlId="envIsPassword">
+                                                    <Form.Check inline type="checkbox" name={'envIsPassword'} checked={cfg.isPassword} onChange={(e) => handleEnvChange(e, envIndex, 'isPassword')} />
+                                                </Form.Group>
+                                            </td>
+                                            <td>
+                                                <Form.Group controlId="envCanOverride">
+                                                    <Form.Check inline type="checkbox" name={'envCanOverride'} checked={cfg.canOverride} onChange={(e) => handleEnvChange(e, envIndex, 'canOverride')} />
+                                                </Form.Group>
+                                            </td>
+                                        </tr>)
+                                    }
+                                        <tr>
+                                            <td>
+                                                <Button className={'btn-primary btn-sm'} onClick={() => addEnv()}>
+                                                    <FontAwesomeIcon icon={faPlus} />
+                                                </Button>
+                                            </td>
+                                            <td></td>
+                                            <td></td>
+                                            <td></td>
+                                            <td></td>
+                                            <td></td>
+                                        </tr>
+                                    </tbody>
+                                </Table>
+                            </Tab>
+
+                            <Tab title={'Volumes'} key={'Volumes'} eventKey={'Volumes'}>
+                                <Table size={'sm'}>
+                                    <thead>
+                                    <tr>
+                                        <th></th>
+                                        <th>Container Mount Path</th>
+                                        <th>From SubPath (optional)</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    {
+                                        spec?.volumeMounts?.map((volume, volIndex) => <tr key={"vol-"+volIndex}>
+                                            <td>
+                                                <Button className={'btn-secondary btn-sm'} onClick={() => removeVolume(volIndex)}>
+                                                    <FontAwesomeIcon icon={faTrash} />
+                                                </Button>
+                                            </td>
+                                            <td>
+                                                <Form.Group controlId="volumeMountPath">
+                                                    <Form.Control name={'volumeMountPath'} type="text" placeholder="Mount path is required"  value={volume.mountPath} onChange={(e) => handleVolChange(e, volIndex, 'mountPath')} />
+                                                </Form.Group>
+                                            </td>
+                                            <td>
+                                                <Form.Group controlId="volumeDefaultPath">
+                                                    <Form.Control type="text" name={'volumeDefaultPath'} placeholder="SubPath from User's Home folder (optional)" value={volume.defaultPath} onChange={(e) => handleVolChange(e, volIndex, 'defaultPath')} />
+                                                </Form.Group>
+                                            </td>
+                                        </tr>)
+                                    }
+                                    <tr>
+                                        <td>
+                                            <Button className={'btn-primary btn-sm'} onClick={() => addVolume()}>
+                                                <FontAwesomeIcon icon={faPlus} />
+                                            </Button>
+                                        </td>
+                                        <td></td>
+                                        <td></td>
+                                    </tr>
+                                    </tbody>
+                                </Table>
+                            </Tab>
+
+                            <Tab title={'Ports'} key={'Ports'} eventKey={'Ports'}>
+                                <Table size={'sm'}>
+                                    <thead>
+                                    <tr>
+                                        <th></th>
+                                        <th>Protocol</th>
+                                        <th>Port Number</th>
+                                        <th>Context Path</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    {
+                                        spec?.ports?.map((port, portIndex) => <tr key={"port-"+portIndex}>
+                                            <td>
+                                                <Button className={'btn-secondary btn-sm'} onClick={() => removePort(portIndex)}>
+                                                    <FontAwesomeIcon icon={faTrash} />
+                                                </Button>
+                                            </td>
+                                            <td>
+                                                <Form.Group controlId="portProtocol">
+                                                    <Form.Control as={'select'} name={'portProtocol'} placeholder="Choose a protocol (optional)" value={port.protocol} onChange={(e) => handlePortChange(e, portIndex, 'protocol')}>
+                                                        <option>HTTP</option>
+                                                        <option>TCP</option>
+                                                        <option>UDP</option>
+                                                    </Form.Control>
+                                                </Form.Group>
+                                            </td>
+                                            <td>
+                                                <Form.Group controlId="portPort">
+                                                    <Form.Control name={'portPort'} type="number" min={1} max={65535} value={port.port} onChange={(e) => handlePortChange(e, portIndex, 'port')} />
+                                                </Form.Group>
+                                            </td>
+                                            <td>
+                                                {
+                                                    port?.protocol?.toLowerCase() === 'http' && <>
+                                                        <Form.Group controlId="portContextPath">
+                                                            <Form.Control required name={'portContextPath'} type="text" placeholder="Enter context path (optional)" value={port.contextPath} onChange={(e) => handlePortChange(e, portIndex, 'contextPath')} />
+                                                        </Form.Group>
+                                                    </>
+                                                }
+                                            </td>
+                                        </tr>)
+                                    }
+                                    <tr>
+                                        <td>
+                                            <Button className={'btn-primary btn-sm'} onClick={() => addPort()}>
+                                                <FontAwesomeIcon icon={faPlus} />
+                                            </Button>
+                                        </td>
+                                        <td></td>
+                                        <td></td>
+                                        <td></td>
+                                    </tr>
+                                    </tbody>
+                                </Table>
+                            </Tab>
+                        </Tabs>
+                    </Form>
+                </Col>
+            </Row>
+            <pre>{JSON.stringify(spec, null, 4)}</pre>
+        </Container>
+    );
+}
+
+export default AddEditSpecPage;

--- a/src/views/my-catalog/AddEditSpec.tsx
+++ b/src/views/my-catalog/AddEditSpec.tsx
@@ -15,12 +15,14 @@ import {Redirect, useParams} from "react-router-dom";
 import ReactGA from "react-ga";
 
 import './AddEditSpec.css';
+import Accordion from 'react-bootstrap/Accordion';
 import Form from "react-bootstrap/Form";
 import {FormControl, Tab, Tabs} from "react-bootstrap";
 import {faPlus} from "@fortawesome/free-solid-svg-icons";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
 import FormGroup from "react-bootstrap/FormGroup";
+import Card from "react-bootstrap/Card";
 
 const sortBy = (s1: V1.Service, s2: V1.Service) => {
     const sid1 = s1.label+"";
@@ -82,8 +84,10 @@ const AddEditSpecPage = (props: any) => {
     });
 
     // User selection
-    const [selectedTab, setSelectedTab] = useState('Basic Info');
+    const [selectedTab, setSelectedTab] = useState('BasicInfo');
     const [redirect, setRedirect] = useState<string>('');
+    const [showJson, setShowJson] = useState(false);
+
 
     useEffect(() => {
         if (env?.customization?.product_name) {
@@ -285,11 +289,29 @@ const AddEditSpecPage = (props: any) => {
         }
     }
 
+    const css = `
+        #outerTabBar-tab-BasicInfo,
+        #outerTabBar-tab-Dependencies,
+        #outerTabBar-tab-Environment,
+        #outerTabBar-tab-Volumes,
+        #outerTabBar-tab-Ports {
+            color: ${darkThemeEnabled ? 'white' : 'black'}
+        }
+        #outerTabBar-tab-BasicInfo.nav-link.active,
+        #outerTabBar-tab-Dependencies.nav-link.active,
+        #outerTabBar-tab-Environment.nav-link.active,
+        #outerTabBar-tab-Volumes.nav-link.active,
+        #outerTabBar-tab-Ports.nav-link.active {
+            color: black;
+        }
+    `;
+
     return (
         <Container fluid={false}>
             {
                 redirect && <Redirect to={redirect} />
             }
+            <style>{css}</style>
             <div style={{ height: "10vh" }}></div>
             <Row>
                 <Col className={'text-align-left'}>
@@ -307,8 +329,13 @@ const AddEditSpecPage = (props: any) => {
             <Row>
                 <Col>
                     <Form>
-                        <Tabs id={'outerTabBar'} activeKey={selectedTab} onSelect={(e: any) => e && setSelectedTab(e)} fill>
-                            <Tab title={'Basic Info'} key={'Basic Info'} eventKey={'Basic Info'}>
+                        <Tabs id={'outerTabBar'} activeKey={selectedTab} onSelect={(e: any) => e && setSelectedTab(e)} fill
+                              style={{
+                                  textAlign: "left",
+                                  color: darkThemeEnabled ? 'white' : 'black',
+                                  backgroundColor: darkThemeEnabled ? '#283845' : '#eee',       // night mode bg / default bg
+                              }}>
+                            <Tab title={'Basic Info'} key={'BasicInfo'} eventKey={'BasicInfo'} style={{ margin: "25px", color: darkThemeEnabled ? 'white' : 'black' }}>
                                 <Row>
                                     <Col className={'text-align-left marginTop'}>
                                         <h3>Basic Info</h3>
@@ -343,7 +370,7 @@ const AddEditSpecPage = (props: any) => {
                                                 }
                                                 <tr>
                                                     <td>
-                                                        <Button className={'btn-secondary btn-sm marginLeft'} onClick={() => addTag()}>
+                                                        <Button className={'btn-primary btn-sm marginLeft'} onClick={() => addTag()}>
                                                             <FontAwesomeIcon icon={faPlus} />
                                                         </Button>
                                                     </td>
@@ -366,11 +393,11 @@ const AddEditSpecPage = (props: any) => {
                                             </Form.Control>
                                         </FormGroup>
                                         <FormGroup>
-                                            <Form.Label>Access</Form.Label>
+                                            <Form.Label>Who else can access this app?</Form.Label>
                                             <Form.Control as="select" defaultValue="external" onChange={(e) => handleFieldChange(e, 'access')}>
-                                                <option value={'external'}>External (ingress + service)</option>
-                                                <option value={'internal'}>Internal (service only)</option>
-                                                <option value={'none'}>None</option>
+                                                <option value={'external'}>External - Publicly Accessible</option>
+                                                <option value={'internal'}>Internal - Accessible only from within Cluster</option>
+                                                <option value={'none'}>None - Isolate this app on the network</option>
                                             </Form.Control>
                                         </FormGroup>
                                     </Col>
@@ -388,7 +415,7 @@ const AddEditSpecPage = (props: any) => {
                                 </Row>
                             </Tab>
                             <Tab title={'Dependencies'} key={'Dependencies'} eventKey={'Dependencies'}>
-                                <Table size={'sm'}>
+                                <Table size={'sm'} borderless={true} style={{ backgroundColor: darkThemeEnabled ? '#283845' : '#fff', color: darkThemeEnabled ? 'white' : 'black' }}>
                                     <thead>
                                     <tr>
                                         <th></th>
@@ -436,7 +463,7 @@ const AddEditSpecPage = (props: any) => {
                                 </Table>
                             </Tab>
                             <Tab title={'Environment'} key={'Environment'} eventKey={'Environment'}>
-                                <Table size={'sm'}>
+                                <Table size={'sm'} borderless={true} style={{ backgroundColor: darkThemeEnabled ? '#283845' : '#fff', color: darkThemeEnabled ? 'white' : 'black' }}>
                                     <thead>
                                         <tr>
                                             <th></th>
@@ -499,7 +526,7 @@ const AddEditSpecPage = (props: any) => {
                             </Tab>
 
                             <Tab title={'Volumes'} key={'Volumes'} eventKey={'Volumes'}>
-                                <Table size={'sm'}>
+                                <Table size={'sm'} borderless={true} style={{ backgroundColor: darkThemeEnabled ? '#283845' : '#fff', color: darkThemeEnabled ? 'white' : 'black' }}>
                                     <thead>
                                     <tr>
                                         <th></th>
@@ -541,7 +568,7 @@ const AddEditSpecPage = (props: any) => {
                             </Tab>
 
                             <Tab title={'Ports'} key={'Ports'} eventKey={'Ports'}>
-                                <Table size={'sm'}>
+                                <Table size={'sm'} borderless={true} style={{ backgroundColor: darkThemeEnabled ? '#283845' : '#fff', color: darkThemeEnabled ? 'white' : 'black' }}>
                                     <thead>
                                     <tr>
                                         <th></th>
@@ -600,7 +627,34 @@ const AddEditSpecPage = (props: any) => {
                     </Form>
                 </Col>
             </Row>
-            <pre>{JSON.stringify(spec, null, 4)}</pre>
+            <Row>
+                <Col>
+                    <Accordion >
+                        <Card id={'showJsonCard'} bg={darkThemeEnabled ? 'dark' : 'light'} style={{ marginTop: "25px", borderRadius: "20px", borderWidth: "2px",
+                            borderColor: darkThemeEnabled ? '#283845' : '#fff',
+                            backgroundColor: darkThemeEnabled ? '#283845' : '#fff' }} text={darkThemeEnabled ? 'light' : 'dark'}>
+                            <Card.Header style={{
+                                textAlign: "left",
+                                borderRadius: showJson ? "18px 18px 0 0" : "18px",
+                                borderBottomColor: !showJson  ? 'transparent' : darkThemeEnabled ? 'white' : 'lightgrey',
+                                color: darkThemeEnabled ? 'white' : 'black',
+                                backgroundColor: darkThemeEnabled ? '#283845' : '#fff',       // night mode bg / default bg
+                            }}>
+                                <Accordion.Toggle as={Button} variant="link" eventKey="0" onClick={() => setShowJson(!showJson)} style={{
+                                    color: darkThemeEnabled ? 'white' : 'black',
+                                    marginRight: "10px",
+                                    marginLeft: "30px"
+                                }}>
+                                    {showJson ? 'Hide' : 'Show'} JSON Spec
+                                </Accordion.Toggle>
+                            </Card.Header>
+                            <Accordion.Collapse eventKey="0" style={{textAlign: "left"}}>
+                                <Card.Body><pre>{JSON.stringify(spec, null, 4)}</pre></Card.Body>
+                            </Accordion.Collapse>
+                        </Card>
+                    </Accordion>
+                </Col>
+            </Row>
         </Container>
     );
 }

--- a/src/views/my-catalog/MyCatalog.css
+++ b/src/views/my-catalog/MyCatalog.css
@@ -1,0 +1,8 @@
+
+.text-align-left {
+    text-align: left;
+}
+.text-align-right {
+    text-align: right;
+}
+

--- a/src/views/my-catalog/MyCatalog.tsx
+++ b/src/views/my-catalog/MyCatalog.tsx
@@ -135,7 +135,7 @@ const MyCatalogPage = (props: any) => {
             }
             <div style={{ height: "10vh" }}></div>
             <h2 className={'marginTop pull-left'}>My Catalog</h2>
-            <button className={'btn-primary btn-sm pull-right'} onClick={()=> createSpec()}>
+            <button className={'btn-secondary btn-lg pull-right'} onClick={()=> createSpec()}>
                 <FontAwesomeIcon icon={faPlus} /> Create New Application
             </button>
             <Table className='compact' responsive='sm' borderless={true} style={{ backgroundColor: darkThemeEnabled ? '#283845' : '#fff', color: darkThemeEnabled ? 'white' : 'black' }}>

--- a/src/views/my-catalog/MyCatalog.tsx
+++ b/src/views/my-catalog/MyCatalog.tsx
@@ -1,0 +1,236 @@
+import React, {useEffect, useState} from 'react';
+import '../../index.css';
+import Button from "react-bootstrap/Button";
+import Container from "react-bootstrap/Container";
+import Modal from "react-bootstrap/Modal";
+import Table from "react-bootstrap/Table";
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {V1, handleError} from "../../common";
+
+import {faTrash} from "@fortawesome/free-solid-svg-icons/faTrash";
+import {faTimes} from "@fortawesome/free-solid-svg-icons/faTimes";
+import {faEdit} from "@fortawesome/free-solid-svg-icons/faEdit";
+
+import {useSelector} from "react-redux";
+import {Redirect} from "react-router-dom";
+import {colors} from "../../App";
+import ReactGA from "react-ga";
+import {faClone, faFileExport, faPlus} from "@fortawesome/free-solid-svg-icons";
+
+import './MyCatalog.css';
+
+const sortBy = (s1: V1.Service, s2: V1.Service) => {
+    const sid1 = s1.label+"";
+    const sid2 = s2.label+""
+    if (sid1 > sid2) {
+        return 1;
+    } else if (sid1 < sid2) {
+        return -1;
+    } else {
+        return 0;
+    }
+}
+
+const MyCatalogPage = (props: any) => {
+    // Global state
+    const darkThemeEnabled = useSelector((state: any) => state.preferences.darkThemeEnabled);
+    const env = useSelector((state: any) => state.env);
+    const user = useSelector((state: any) => state.auth.user);
+
+    // Server data
+    const [stacks, setStacks] = useState<Array<V1.Stack>>([]);
+    const [specs, setSpecs] = useState<Array<V1.Service>>([]);
+
+    const [redirect, setRedirect] = useState<string>('');
+
+    // Delete confirmation
+    const [showConfirmDelete, setShowConfirmDelete] = useState<boolean>(false);
+    const [selectedSpec, setSelectedSpec] = useState<V1.Service>();
+
+    useEffect(() => {
+        if (env?.customization?.product_name) {
+            document.title = `${env?.customization?.product_name}: My Catalog`;
+        }
+    }, [env]);
+
+    useEffect(() => {
+        if (env?.analytics_tracking_id) {
+            ReactGA.pageview('/my-catalog');
+        }
+    }, [env?.analytics_tracking_id]);
+
+    useEffect(() => {
+        if (!Object.keys(env).length) return;
+        let filter = (s: V1.Service) => s.catalog === 'user';
+        if (user?.groups?.includes('/workbench-admins')) {
+            filter = () => true;
+        }
+        V1.AppSpecService.listServicesAll().then(specs => setSpecs(specs.filter(filter))).catch(reason => handleError('Failed to fetch specs: ', reason));
+        V1.UserAppService.listUserapps().then(stacks => setStacks(stacks)).catch(reason => handleError('Failed to fetch stacks: ', reason));
+    }, [env, user?.groups]);
+
+    const cloneSpec = async (spec: V1.Service) => {
+        if (!spec || !spec.key) { return; }
+        const existing: V1.Service = await V1.AppSpecService.getServiceById(spec.key);
+
+        existing.id = '';
+        existing.catalog = 'user';
+        existing.label = 'Copy of ' + (existing.label || existing.key)
+        existing.key = existing.key + 'copy'
+
+        const copied = await V1.AppSpecService.createService(existing);
+        setRedirect('/my-catalog/'+copied.key);
+    }
+
+    const deleteSelectedSpec = () => {
+        if (!selectedSpec || !selectedSpec.key) { return; }
+        V1.AppSpecService.deleteService(selectedSpec.key).then((deleted) => {
+            const s = specs.find(s => s.key === selectedSpec.key);
+            if (s) {
+                const index = specs.indexOf(s);
+                specs.splice(index, 1);
+            }
+            setShowConfirmDelete(false);
+        });
+    }
+
+    const createSpec = () => {
+        setRedirect('/my-catalog/create');
+    }
+
+    const editSpec = (spec?: V1.Service) => {
+        if (!spec || !spec.key) { return; }
+        setRedirect('/my-catalog/' + spec.key);
+    }
+
+    const importSpec = async (jsonStr: string) => {
+        if (!jsonStr) { return; }
+
+        try {
+            const spec = JSON.parse(jsonStr);
+            const imported = await V1.AppSpecService.createService(spec);
+        } catch (e) {
+            console.log('Failed to parse JSON: ', e);
+            return;
+        }
+        // TODO: navigate to /all-apps/{id}/edit
+    }
+
+    const exportSpec = (spec?: V1.Service) => {
+        if (!spec || !spec.id) { return; }
+        const jsonStr = JSON.stringify(spec);
+
+        // TODO: show modal?
+    }
+
+    const confirmDelete = (spec: V1.Service) => {
+        setSelectedSpec(spec);
+        setShowConfirmDelete(true);
+    }
+
+    return (
+        <Container fluid={false}>
+            {
+                redirect && <Redirect to={redirect} />
+            }
+            <div style={{ height: "10vh" }}></div>
+            <h2 className={'marginTop pull-left'}>My Catalog</h2>
+            <button className={'btn-primary btn-sm pull-right'} onClick={()=> createSpec()}>
+                <FontAwesomeIcon icon={faPlus} /> Create New Application
+            </button>
+            <Table className='compact' responsive='sm' borderless={true} style={{ backgroundColor: darkThemeEnabled ? '#283845' : '#fff', color: darkThemeEnabled ? 'white' : 'black' }}>
+                <thead>
+                <tr>
+                    <th>Key</th>
+                    <th>Name</th>
+                    <th style={{ width: '10%' }}>Export</th>
+                    <th style={{ width: '10%' }}>Clone</th>
+                    <th style={{ width: '10%' }}>Edit</th>
+                    <th style={{ width: '10%' }}>Delete</th>
+                </tr>
+                </thead>
+                <tbody>
+                {
+                    specs.sort(sortBy).map(spec =>
+                        <tr key={spec.key}>
+                            <td>{spec.key}</td>
+                            <td>{spec.label}</td>
+                            <td>
+                                <Button title={'Export Application Spec'} size={'sm'} style={{
+                                    color: darkThemeEnabled ? colors.textColor.dark: colors.textColor.light,
+                                    backgroundColor: darkThemeEnabled ? colors.backgroundColor.dark: colors.backgroundColor.light
+                                }} onClick={() => exportSpec(spec)}>
+                                    <FontAwesomeIcon icon={faFileExport} />
+                                </Button>
+                            </td>
+                            <td>
+                                <Button title={'Clone Application Spec'} size={'sm'} style={{
+                                    color: darkThemeEnabled ? colors.textColor.dark: colors.textColor.light,
+                                    backgroundColor: darkThemeEnabled ? colors.backgroundColor.dark: colors.backgroundColor.light
+                                }} onClick={() => cloneSpec(spec)}>
+                                    <FontAwesomeIcon icon={faClone} />
+                                </Button>
+                            </td>
+                            <td>
+                                <Button title={'Edit Application Spec'} size={'sm'} style={{
+                                    color: darkThemeEnabled ? colors.textColor.dark: colors.textColor.light,
+                                    backgroundColor: darkThemeEnabled ? colors.backgroundColor.dark: colors.backgroundColor.light
+                                }} onClick={() => editSpec(spec)}>
+                                    <FontAwesomeIcon icon={faEdit} />
+                                </Button>
+                            </td>
+                            <td>
+                                <Button title={'Delete Application Spec'} size={'sm'} style={{
+                                    color: darkThemeEnabled ? colors.textColor.dark: colors.textColor.light,
+                                    backgroundColor: darkThemeEnabled ? colors.backgroundColor.dark: colors.backgroundColor.light
+                                }} onClick={() => confirmDelete(spec)}>
+                                    <FontAwesomeIcon icon={faTrash} />
+                                </Button>
+                            </td>
+                        </tr>
+
+                    )
+                }
+                </tbody>
+            </Table>
+
+            <Modal show={showConfirmDelete}
+                   fullscreen={'true'}>
+                <Modal.Header style={{
+                    backgroundColor: darkThemeEnabled ? colors.foregroundColor.dark : colors.foregroundColor.light,
+                    color: darkThemeEnabled ? colors.textColor.dark : colors.textColor.light,
+                }}>
+                    <Modal.Title>Confirm Delete: {selectedSpec?.id}</Modal.Title>
+                    <div>
+                        <Button variant={darkThemeEnabled ? 'dark' : 'light'} onClick={() => setShowConfirmDelete(false)}>
+                            <FontAwesomeIcon icon={faTimes} />
+                        </Button>
+                    </div>
+                </Modal.Header>
+                <Modal.Body style={{
+                    backgroundColor: darkThemeEnabled ? colors.backgroundColor.dark : colors.backgroundColor.light,
+                    color: darkThemeEnabled ? colors.textColor.dark : colors.textColor.light,
+                }}>
+                    <p>You are about to delete the following catalog application: {selectedSpec?.label}.</p>
+                    <p>Are you sure?</p>
+                </Modal.Body>
+                <Modal.Footer style={{
+                    backgroundColor: darkThemeEnabled ? colors.foregroundColor.dark : colors.foregroundColor.light,
+                    color: darkThemeEnabled ? colors.textColor.dark : colors.textColor.light,
+                }}>
+                    <Button variant="secondary" onClick={() => setShowConfirmDelete(false)}>No</Button>
+                    <Button variant="primary" onClick={() => deleteSelectedSpec()}>Yes</Button>
+                </Modal.Footer>
+            </Modal>
+        </Container>
+    );
+    /*
+    <Modal.Footer>
+                    <Button variant="secondary" onClick={closeConsole}>
+                        Close
+                    </Button>
+                </Modal.Footer>
+     */
+}
+
+export default MyCatalogPage;


### PR DESCRIPTION
## Problem
There is no UI for the user to add/edit application specs or to manage their own list of applications

## Approach
* Created `AddEditSpecPage` where a specific AppSpec can be viewed or altered, or a new one can be created entirely
* Created `MyCatalogPage` where user's personal catalog can be viewed and altered
* Hide these new views behind the `workbench-developers` group / role in Keycloak - only users in this group will see the new feature