### PR TITLE
fix: use NodeJS 18 in Dockerfile.dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:18
 WORKDIR /app
 
 COPY package.json yarn.lock ./


### PR DESCRIPTION
## Problem
Workbench WebUI has been updated throughout to use NodeJS 18

`Dockerfile.dev` still uses Node 14, which causes a build failure

## Approach
Use `node:18` instead of `node:14` for `Dockerfile.dev` - this image enabled live-reload when used with `make dev` in the [Workbench Helm Chart](https://github.com/nds-org/workbench-helm-chart)

## How to Test
1. Checkout workbench-helm-chart locally: `git clone https://github.com/nds-org/workbench-helm-chart`
2. Run the dev environment with live reload: `make dev`
3. Wait for Workbench WebUI container to start up
    * You should not see the Workbench Pod go into `CrashLoopBackoff` - the container should start up as expected