### PR TITLE
fix: async behavior when creating/updating a spec

### DIFF
--- a/src/views/my-catalog/AddEditSpec.tsx
+++ b/src/views/my-catalog/AddEditSpec.tsx
@@ -319,25 +319,24 @@ const AddEditSpecPage = (props: any) => {
         setRedirect('/my-catalog');
     }
 
-    const saveSpec = async (spec: V1.Service) => {
+    const saveSpec = (spec: V1.Service) => {
         if (spec.catalog === 'system' && !user?.groups?.includes('/workbench-admin')) {
             // User is not an admin
             return;
         }
 
         if (!spec || !spec.key) { return; }
-        const existing: V1.Service = await V1.AppSpecService.getServiceById(spec.key);
-
-
-        if (existing) {
+        return V1.AppSpecService.getServiceById(spec.key).then((existing) => {
+            console.log('Spec exists, updating it now: ', spec);
             return V1.AppSpecService.updateService(spec.key, spec).then((updated: V1.Service) => {
                 setRedirect('/my-catalog')
-            });
-        } else {
+            })
+        }).catch(e => {
+            console.log('Spec does not exist, creating it now: ', spec);
             return V1.AppSpecService.createService(spec).then((created: V1.Service) => {
                 setRedirect('/my-catalog')
             });
-        }
+        });
     }
 
     const css = `
@@ -402,7 +401,7 @@ const AddEditSpecPage = (props: any) => {
                                         </FormGroup>
                                     </Col>
                                 </Row>
-                                
+
                                 <h3 className={'text-align-left marginTop'}>Docker Info</h3>
                                 <Row>
                                     <Col className={'text-align-left marginTop'}>


### PR DESCRIPTION
## Problem
When saving a new appspec, the UI throws the following error:
```
# 404 error resulting from existence check
>     GET https://kubernetes.docker.internal/api/v1/services/yay 404
sendRequest @ request.ts:131
await in sendRequest (async)

# I thought that this "uncaught" error would just return undefined.. apparently that is not the case
>     Uncaught (in promise) Error: Not found - spec key not found
    at catchErrors (request.ts:175:1)
    at request (request.ts:203:1)
    at async AppSpecService.getServiceById (AppSpecService.ts:96:1)
    at async saveSpec (AddEditSpec.tsx:329:1)
catchErrors @ request.ts:175
request @ request.ts:203
await in request (async)
onClick @ AddEditSpec.tsx:375 

# This only appears in development mode, but "process" is usually a server-side thing...
>      Uncaught ReferenceError: process is not defined
```

Apparently we need a `.catch` clause when async/await will hit an error

## Approach
* Remove async/await here, switch back to using a classic Promise
* Add a proper error handler

## How to Test
Prerequisites:
* `workbench-helm-chart` checked out locally
* `cd src/webui/`
* User added to `workbench-developers` group in Keycloak

Test Steps:
1. Checkout this branch and run locally: `make compile`
2. Login to Workbench WebUI via Keycloak user
3. Navigate to My Catalog
4. Click the "Create New Application" button
5. Enter spec details:
    * key: `anything`
    * image: `something`
    * ports: 8888
6. Click Save
    * You should be redirected back to the My Catalog view
    * You should see your new application now appears in the list