### PR TITLE
feat: Validation in MyCatalog + import/export specs, consistency for helpers

### DIFF
--- a/src/common/dialogs/ConfirmDialog.tsx
+++ b/src/common/dialogs/ConfirmDialog.tsx
@@ -1,0 +1,56 @@
+import Modal from "react-bootstrap/Modal";
+import {colors} from "../../App";
+import Button from "react-bootstrap/Button";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faTimes} from "@fortawesome/free-solid-svg-icons/faTimes";
+import React from "react";
+import {useSelector} from "react-redux";
+
+interface ConfirmDialogProps {
+    // Primitives
+    title: string;
+    show: boolean;
+
+    // Event handlers
+    onClose: (props: ConfirmDialogProps) => void;
+    onConfirm: (props: ConfirmDialogProps) => void;
+
+    // Child elements (content)
+    children: any;
+}
+
+const ConfirmDialog = (props: ConfirmDialogProps) => {
+    // Global state
+    const darkThemeEnabled = useSelector((state: any) => state.preferences.darkThemeEnabled);
+
+    return (
+        <Modal show={props.show}
+               fullscreen={'true'}>
+            <Modal.Header style={{
+                backgroundColor: darkThemeEnabled ? colors.foregroundColor.dark : colors.foregroundColor.light,
+                color: darkThemeEnabled ? colors.textColor.dark : colors.textColor.light,
+            }}>
+                <Modal.Title>{props.title}</Modal.Title>
+                <div>
+                    <Button variant={darkThemeEnabled ? 'dark' : 'light'} onClick={() => props.onClose(props)}>
+                        <FontAwesomeIcon icon={faTimes}/>
+                    </Button>
+                </div>
+            </Modal.Header>
+            <Modal.Body style={{
+                backgroundColor: darkThemeEnabled ? colors.backgroundColor.dark : colors.backgroundColor.light,
+                color: darkThemeEnabled ? colors.textColor.dark : colors.textColor.light,
+            }}>
+                {props.children}
+            </Modal.Body>
+            <Modal.Footer style={{
+                backgroundColor: darkThemeEnabled ? colors.foregroundColor.dark : colors.foregroundColor.light,
+                color: darkThemeEnabled ? colors.textColor.dark : colors.textColor.light,
+            }}>
+                <Button variant="secondary" onClick={() => props.onClose(props)}>No</Button>
+                <Button variant="primary" onClick={() => props.onConfirm(props)}>Yes</Button>
+            </Modal.Footer>
+        </Modal>);
+}
+
+export default ConfirmDialog;

--- a/src/common/dialogs/ImportExportSpecDialog.tsx
+++ b/src/common/dialogs/ImportExportSpecDialog.tsx
@@ -140,10 +140,23 @@ const ImportExportSpecDialog = (props: ImportExportSpecDialogProps) => {
             }}>
                 {
                     props.spec ? <>
-                        <pre>{JSON.stringify(props.spec, null ,4)}</pre>
+                        <pre style={{
+                            padding: '10px',
+                            borderRadius: '5px',
+                            borderWidth: '1pt',
+                            borderStyle: 'solid',
+                            borderColor: darkThemeEnabled ? colors.textColor.dark : colors.textColor.light,
+                            backgroundColor: darkThemeEnabled ? colors.foregroundColor.dark : colors.foregroundColor.light,
+                            color: darkThemeEnabled ? colors.textColor.dark : colors.textColor.light,
+                        }}>{JSON.stringify(props.spec, null ,4)}</pre>
                     </> :
                     <>
-                        <FormControl style={{height: props.height || '40vh'}} as={'textarea'} required value={specJsonToImport} onChange={(e) => handleSpecJsonChanged(e)}></FormControl>
+                        <FormControl style={{
+                            height: props.height || '40vh',
+                            borderColor: darkThemeEnabled ? colors.textColor.dark : colors.textColor.light,
+                            backgroundColor: darkThemeEnabled ? colors.foregroundColor.dark : colors.foregroundColor.light,
+                            color: darkThemeEnabled ? colors.textColor.dark : colors.textColor.light,
+                        }} as={'textarea'} required value={specJsonToImport} onChange={(e) => handleSpecJsonChanged(e)}></FormControl>
                     </>
                 }
 

--- a/src/common/dialogs/ImportExportSpecDialog.tsx
+++ b/src/common/dialogs/ImportExportSpecDialog.tsx
@@ -1,13 +1,14 @@
+import {Dispatch, SetStateAction, useState} from "react";
 import {useSelector} from "react-redux";
-import Modal from "react-bootstrap/Modal";
 import Button from "react-bootstrap/Button";
+import FormControl from "react-bootstrap/FormControl";
+import Modal from "react-bootstrap/Modal";
+
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faTimes} from "@fortawesome/free-solid-svg-icons/faTimes";
+
 import {colors} from "../../App";
-import {deepCopy, V1} from "../services";
-import {FormControl} from "react-bootstrap";
-import React, {Dispatch, SetStateAction, useState} from "react";
-import {newSpec} from "../services/userapps.service";
+import {V1, newSpec} from "../services";
 
 interface ImportExportSpecDialogProps {
     // Content properties
@@ -27,7 +28,6 @@ interface ImportExportSpecDialogProps {
 const ImportExportSpecDialog = (props: ImportExportSpecDialogProps) => {
     // Global state
     const darkThemeEnabled = useSelector((state: any) => state.preferences.darkThemeEnabled);
-    const user = useSelector((state: any) => state.auth.user);
 
     const [specJsonToImport, setSpecJsonToImport] = useState<string | undefined>(JSON.stringify(newSpec(), null ,2));
     const [errorMessage, setErrorMessage] = useState<string>('');
@@ -87,6 +87,12 @@ const ImportExportSpecDialog = (props: ImportExportSpecDialogProps) => {
             if (!spec?.key) {
                 console.error('Error: you must assign a unique key to this service to save it');
                 setErrorMessage('"key" is required');
+                return;
+            }
+
+            if (!spec?.image.name) {
+                console.error('Error: you must assign a Docker image name to run for this app');
+                setErrorMessage('"image.name" is required');
                 return;
             }
 

--- a/src/common/dialogs/ImportExportSpecDialog.tsx
+++ b/src/common/dialogs/ImportExportSpecDialog.tsx
@@ -1,0 +1,161 @@
+import {useSelector} from "react-redux";
+import Modal from "react-bootstrap/Modal";
+import Button from "react-bootstrap/Button";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faTimes} from "@fortawesome/free-solid-svg-icons/faTimes";
+import {colors} from "../../App";
+import {deepCopy, V1} from "../services";
+import {FormControl} from "react-bootstrap";
+import React, {Dispatch, SetStateAction, useState} from "react";
+import {newSpec} from "../services/userapps.service";
+
+interface ImportExportSpecDialogProps {
+    // Content properties
+    title?: string;
+    spec?: V1.Service;
+
+    // Display properties
+    show: boolean;
+    height?: string;
+
+    // Event handlers
+    onClose?: (props: ImportExportSpecDialogProps) => void;
+    onConfirm?: (props: ImportExportSpecDialogProps) => void;
+    setRedirect?: Dispatch<SetStateAction<string>>
+}
+
+const ImportExportSpecDialog = (props: ImportExportSpecDialogProps) => {
+    // Global state
+    const darkThemeEnabled = useSelector((state: any) => state.preferences.darkThemeEnabled);
+    const user = useSelector((state: any) => state.auth.user);
+
+    const [specJsonToImport, setSpecJsonToImport] = useState<string | undefined>(JSON.stringify(newSpec(), null ,2));
+    const [errorMessage, setErrorMessage] = useState<string>('');
+
+    const handleSpecJsonChanged = (event: any) => {
+        setSpecJsonToImport(event.target.value);
+    };
+
+    const onConfirm = (event: any) => {
+        if (props.spec) {
+            console.log('Exporting spec: ', props.spec);
+            exportSpec(props.spec);
+        } else if (specJsonToImport) {
+            console.log('Importing spec: ', specJsonToImport);
+            importSpec(specJsonToImport);
+        }
+        if (props.onConfirm) {
+            props.onConfirm(props)
+        }
+    }
+
+    const onClose = (event: any) => {
+        if (props.onClose) {
+            props.onClose(props)
+        }
+    }
+
+    const isDisabled = (): boolean => {
+        if (props.spec) {
+            return false;
+        } else if (specJsonToImport) {
+            try {
+                return !JSON.parse(specJsonToImport);
+            } catch {
+                return true;
+            }
+        }
+
+        return true;
+    }
+
+    const exportSpec = (spec: V1.Service) => {
+        try {
+            const json = JSON.stringify(spec, undefined, 2);
+            navigator.clipboard.writeText(json).then(() => {
+                console.log('Spec JSON copied to clipboard!');
+            }).catch((e) => {
+                console.error('Failed to copy text to clipboard: ', e);
+            });
+        } catch (e) {
+            console.error('Error copying text to clipboard: ', e);
+        }
+    }
+    const importSpec = (specJson: string) => {
+        try {
+            const spec: V1.Service = JSON.parse(specJson);
+            if (!spec?.key) {
+                console.error('Error: you must assign a unique key to this service to save it');
+                setErrorMessage('"key" is required');
+                return;
+            }
+
+            return V1.AppSpecService.getServiceById(spec.key).then((existing) => {
+                console.error(`Failed to save spec: key=${spec.key} already exists: `, existing);
+                setErrorMessage('Spec already exists: ' + spec.key);
+            }).catch((e) => {
+                return V1.AppSpecService.createService(spec).then(imported => {
+                    // navigate to /all-apps/{key}/edit
+                    console.log('Successfully imported spec: ', imported);
+                    if (props.setRedirect) {
+                        props.setRedirect(`/all-apps/${imported.key}`);
+                    }
+                }).catch((e) => {
+                    console.error(`Failed to import new spec with key=${spec.key}: `, e);
+                    setErrorMessage(e);
+                });
+            });
+
+
+        } catch (e) {
+            console.error('Failed to parse JSON: ', e);
+            setErrorMessage('Invalid JSON: ' + e);
+        }
+    }
+
+    return (
+        <Modal show={props.show}
+               size={'lg'}
+               fullscreen={'true'}>
+            <Modal.Header style={{
+                backgroundColor: darkThemeEnabled ? colors.foregroundColor.dark : colors.foregroundColor.light,
+                color: darkThemeEnabled ? colors.textColor.dark : colors.textColor.light,
+            }}>
+                <Modal.Title>{props.title ? props.title : props.spec ? `Export Spec: ${props.spec.key}` : 'Import New Spec'}</Modal.Title>
+                <div>
+                    <Button variant={darkThemeEnabled ? 'dark' : 'light'} onClick={onClose}>
+                        <FontAwesomeIcon icon={faTimes}/>
+                    </Button>
+                </div>
+            </Modal.Header>
+            <Modal.Body style={{
+                backgroundColor: darkThemeEnabled ? colors.backgroundColor.dark : colors.backgroundColor.light,
+                color: darkThemeEnabled ? colors.textColor.dark : colors.textColor.light,
+            }}>
+                {
+                    props.spec ? <>
+                        <pre>{JSON.stringify(props.spec, null ,4)}</pre>
+                    </> :
+                    <>
+                        <FormControl style={{height: props.height || '40vh'}} as={'textarea'} required value={specJsonToImport} onChange={(e) => handleSpecJsonChanged(e)}></FormControl>
+                    </>
+                }
+
+            </Modal.Body>
+            <Modal.Footer style={{
+                backgroundColor: darkThemeEnabled ? colors.foregroundColor.dark : colors.foregroundColor.light,
+                color: darkThemeEnabled ? colors.textColor.dark : colors.textColor.light,
+            }}>
+                <span style={{ color: 'red' }}>{errorMessage}</span>
+                <Button variant="secondary" onClick={onClose}>Cancel</Button>
+                <Button variant="primary" onClick={onConfirm} disabled={isDisabled()}>
+                    {
+                        props.spec ? 'Copy to Clipboard' : 'Import'
+                    }
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+}
+
+export default ImportExportSpecDialog;

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -49,43 +49,6 @@ import {faPlus} from "@fortawesome/free-solid-svg-icons/faPlus";*/
 //export { Container, Alert, Carousel, Button, Form, FormControl, FormGroup, FormLabel, Accordion, Card, Col, Row, Modal, Table, ListGroup, Jumbotron, Dropdown, DropdownButton, Navbar, Nav, NavDropdown };
 //export {FontAwesomeIcon, faPlus, faCloudMoon, faCloudSun, faCheckCircle, faExclamationCircle, faPowerOff, faSpinner, faTerminal, faTrash, faRocket, faStop, faCaretDown, faLink, faTimes, faExpand, faEllipsisV, faChevronLeft}
 
-export const UNAUTHORIZED_401 = (reason: Error) => {return reason.message.includes('Unauthorized');}
-export const CONFLICT_409 = (reason: Error) => {return reason.message.includes('Conflict');}
-
-const handleError = (message: string, reason: Error, onUnath?: () => void) => {
-    console.error(`${message}: `, reason);
-    console.error("Should redirect to login view...");
-    const isAuthErr = UNAUTHORIZED_401(reason);
-
-    if (isAuthErr) {
-        // Clear any stale auth info
-        localStorage.removeItem('auth');
-
-        if (onUnath) {
-            onUnath();
-        }
-
-        // Hard redirect to login (include return route)
-        console.error("Redirecting to login view...");
-        if (window.location.pathname !== '/' && !window.location.pathname.includes('login')) {
-            window.location.href = '/login?rd=' + encodeURIComponent(window.location.pathname);
-        }
-    } else {
-        console.log('Full reason: ', reason);
-    }
-
-}
-
-const waitFor = (condition: () => Promise<boolean>, period: number = 2000) => {
-    let interval = setInterval(async () => {
-        // Check if condition is true
-        condition().then(bool => {
-            bool && clearInterval(interval);
-        }).catch(reason => clearInterval(interval));
-    }, period);
-}
-
-export { handleError, waitFor };
 
 export * from './services';
 export * from './layout';

--- a/src/common/services/index.ts
+++ b/src/common/services/index.ts
@@ -5,7 +5,7 @@
 import * as V1 from './openapi/v1';
 import * as V2 from './openapi/v2';
 
-import { copy, newStack, newStackService } from './userapps.service';
+import { deepCopy, newStack, newStackService, copySpec } from './userapps.service';
 
 /*const token = cookies.get('token');
 if (token) {
@@ -27,4 +27,40 @@ if (token) {
 }, 10000);*/
 
 
-export { V1, V2, copy, newStack, newStackService };
+export const UNAUTHORIZED_401 = (reason: Error) => {return reason.message.includes('Unauthorized');}
+export const CONFLICT_409 = (reason: Error) => {return reason.message.includes('Conflict');}
+
+const handleError = (message: string, reason: Error, onUnath?: () => void) => {
+    console.error(`${message}: `, reason);
+    console.error("Should redirect to login view...");
+    const isAuthErr = UNAUTHORIZED_401(reason);
+
+    if (isAuthErr) {
+        // Clear any stale auth info
+        localStorage.removeItem('auth');
+
+        if (onUnath) {
+            onUnath();
+        }
+
+        // Hard redirect to login (include return route)
+        console.error("Redirecting to login view...");
+        if (window.location.pathname !== '/' && !window.location.pathname.includes('login')) {
+            window.location.href = '/login?rd=' + encodeURIComponent(window.location.pathname);
+        }
+    } else {
+        console.log('Full reason: ', reason);
+    }
+
+}
+
+const waitFor = (condition: () => Promise<boolean>, period: number = 2000) => {
+    let interval = setInterval(async () => {
+        // Check if condition is true
+        condition().then(bool => {
+            bool && clearInterval(interval);
+        }).catch(reason => clearInterval(interval));
+    }, period);
+}
+
+export { handleError, waitFor, V1, V2, deepCopy, copySpec, newStack, newStackService };

--- a/src/common/services/index.ts
+++ b/src/common/services/index.ts
@@ -5,7 +5,7 @@
 import * as V1 from './openapi/v1';
 import * as V2 from './openapi/v2';
 
-import { deepCopy, newStack, newStackService, copySpec } from './userapps.service';
+import { deepCopy, newSpec, newStack, newStackService, copySpec } from './userapps.service';
 
 /*const token = cookies.get('token');
 if (token) {
@@ -63,4 +63,4 @@ const waitFor = (condition: () => Promise<boolean>, period: number = 2000) => {
     }, period);
 }
 
-export { handleError, waitFor, V1, V2, deepCopy, copySpec, newStack, newStackService };
+export { copySpec, deepCopy, handleError, newSpec, newStack, newStackService, V1, V2, waitFor };

--- a/src/common/services/openapi/v1/core/OpenAPI.ts
+++ b/src/common/services/openapi/v1/core/OpenAPI.ts
@@ -18,7 +18,7 @@ type Config = {
 
 export const OpenAPI: Config = {
     BASE: '/api/v1',
-    VERSION: '2.1.0',
+    VERSION: '2.1.1',
     WITH_CREDENTIALS: false,
     TOKEN: undefined,
     USERNAME: undefined,

--- a/src/common/services/openapi/v1/services/SystemService.ts
+++ b/src/common/services/openapi/v1/services/SystemService.ts
@@ -12,8 +12,11 @@ export class SystemService {
      * @throws ApiError
      */
     public static async getVersion(): Promise<{
+        name?: string,
         version?: string,
         hash?: string,
+        branch?: string,
+        buildnumber?: string,
     }> {
         const result = await __request({
             method: 'GET',

--- a/src/common/services/userapps.service.ts
+++ b/src/common/services/userapps.service.ts
@@ -1,7 +1,75 @@
-import {V1} from "./index";
+/**
+ * Helpers and utility functions for working with UserApps.
+ */
 
-export const copy = (obj: any) => {
+
+import { V1 } from ".";
+
+export const deepCopy = (obj: any) => {
     return JSON.parse(JSON.stringify(obj));
+}
+
+export const newSpec = (): V1.Service => ({
+    // Basic Info
+    key: '',
+    label: '',
+
+    // Access Info
+    display: 'stack',
+    access: 'external',
+
+    // Docker info
+    image: {
+        name: '',
+        tags: ['latest']
+    },
+
+    // Help Info
+    logo: '/ndslabs-badge.png',
+    info: '',
+
+    // Tabbed info
+    depends: [],
+    config: [],
+    ports: [],
+    volumeMounts: [],
+
+    // TODO: no UI for these yet (advanced features)
+    additionalResources: [],
+    developerEnvironment: undefined,
+    repositories: [],
+    command: [],
+    args: [],
+    catalog: 'user',
+    tags: []
+});
+
+export const copySpec = (spec: V1.Service): V1.Service => {
+    const specCopy = {...spec};
+
+    // AppSpec metadata
+    specCopy.id = '';
+    specCopy.key = specCopy.key + 'copy';
+    specCopy.label = 'Copy of ' + (specCopy.label || specCopy.key);
+    specCopy.catalog = 'user';
+
+    // Docker Image / tags / resource limits
+    specCopy.image.name = specCopy.image.name || '';
+    specCopy.image.tags = specCopy.image.tags || ['latest'];
+    specCopy.resourceLimits = undefined;
+
+    // Command / arg
+    specCopy.command = specCopy.command || [];
+    specCopy.args = specCopy.args || [];
+
+    // Array properties
+    specCopy.repositories = specCopy.repositories || [];
+    specCopy.ports = specCopy.ports || [];
+    specCopy.config = specCopy.config || [];
+    specCopy.volumeMounts = specCopy.volumeMounts || [];
+    specCopy.additionalResources = specCopy.additionalResources || [];
+
+    return specCopy;
 }
 
 export const newStack = (appSpec: V1.Service, allSpecs: Array<V1.Service>): V1.Stack => {
@@ -9,7 +77,7 @@ export const newStack = (appSpec: V1.Service, allSpecs: Array<V1.Service>): V1.S
 
     const stack: V1.Stack = {
         id: "",
-        name: copy(appSpec.label),
+        name: deepCopy(appSpec.label),
         key: key,
         // secure: this.copy(appSpec.authRequired),
         status: "stopped",
@@ -24,19 +92,20 @@ export const newStack = (appSpec: V1.Service, allSpecs: Array<V1.Service>): V1.S
     const deps = appSpec.depends || [];
 
     // Add required service dependencies
-    deps.filter(dep => dep.required).forEach((reqDep: V1.ServiceDependency) => {
-        const depKey = reqDep.key;
-        if (!depKey) {
-            console.error(`Empty key encountered: ${appSpec.key}-${depKey}   <--- this shouldn't be empty`);
-        } else {
-            const depSpec = allSpecs.find(spec => spec.key === reqDep.key);
-            if (depSpec) {
-                services.push(newStackService(depSpec, stack));
+    deps.filter((dep: V1.ServiceDependency) => dep.required)
+        .forEach((reqDep: V1.ServiceDependency) => {
+            const depKey = reqDep.key;
+            if (!depKey) {
+                console.error(`Empty key encountered: ${appSpec.key}-${depKey}   <--- this shouldn't be empty`);
             } else {
-                console.error("Spec not found: " + reqDep.key);
+                const depSpec = allSpecs.find(spec => spec.key === reqDep.key);
+                if (depSpec) {
+                    services.push(newStackService(depSpec, stack));
+                } else {
+                    console.error("Spec not found: " + reqDep.key);
+                }
             }
-        }
-    });
+        });
 
     stack.services = services;
 

--- a/src/views/all-apps/SpecCard.tsx
+++ b/src/views/all-apps/SpecCard.tsx
@@ -1,22 +1,28 @@
+// React + plugins
 import {useState} from 'react';
 import {Navigate} from "react-router-dom";
 import {useSelector} from "react-redux";
-
+import ReactGA from "react-ga";
 import Button from "react-bootstrap/Button";
+import ButtonGroup from "react-bootstrap/ButtonGroup";
 import Card from "react-bootstrap/Card";
 import Col from "react-bootstrap/Col";
+import Dropdown from "react-bootstrap/Dropdown";
 import Row from "react-bootstrap/Row";
-import {faEllipsisV} from '@fortawesome/free-solid-svg-icons/faEllipsisV';
-import {CONFLICT_409, handleError, V1} from '../../common';
-import Taglist from "./Taglist";
 
-import './SpecCard.css';
+// FontAwesome
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {faCopy} from "@fortawesome/free-solid-svg-icons/faCopy";
+import {faEllipsisV} from '@fortawesome/free-solid-svg-icons/faEllipsisV';
 import {faPlus} from "@fortawesome/free-solid-svg-icons/faPlus";
-import ReactGA from "react-ga";
-import {newStack} from "../../common/services/userapps.service";
-import {faCopy} from "@fortawesome/free-solid-svg-icons";
-import {ButtonGroup, Dropdown} from "react-bootstrap";
+
+// Custom helpers
+import Taglist from "./Taglist";
+import {newStack, copySpec, CONFLICT_409, handleError, V1} from "../../common/services";
+
+import '../../index.css';
+import './SpecCard.css';
+
 
 // TODO: Abstract this?
 
@@ -56,29 +62,22 @@ function SpecCard(props: CardProps) {
     }
 
     const cloneSpec = (): void => {
-        const spec = {...props.spec};
+        const specCopy = copySpec(props.spec);
 
-        spec.id = '';
-        spec.catalog = 'user';
-        spec.label = 'Copy of ' + (spec.label || spec.key);
-        spec.key = spec.key + 'copy';
-        spec.resourceLimits = undefined;
-        spec.repositories = spec.repositories || [];
-
-        V1.AppSpecService.createService(spec).then(appSpec => {
+        V1.AppSpecService.createService(specCopy).then(appSpec => {
             ReactGA.event({
                 category: 'application',
                 action: 'clone',
                 label: appSpec.key
             });
             props.specs.push(appSpec);
-            setRedirect(`/my-catalog`);
+            setRedirect(`/my-catalog/${appSpec.key}`);
         }).catch(reason => {
             if (CONFLICT_409(reason)) {
-                // Copy of this spec already exists, redirect to catalog to see it
-                setRedirect(`/my-catalog`);
+                // Copy of this spec already exists, redirect to the copy
+                setRedirect(`/my-catalog/${specCopy.key}`);
             } else {
-                handleError(`Failed to clone ${spec.key} app spec`, reason)
+                handleError(`Failed to clone ${specCopy.key} app spec`, reason)
             }
         });
     }

--- a/src/views/my-catalog/AddEditSpec.css
+++ b/src/views/my-catalog/AddEditSpec.css
@@ -24,3 +24,7 @@
 .text-red {
     color: red;
 }
+
+.m-10 {
+    margin: 10px;
+}

--- a/src/views/my-catalog/AddEditSpec.tsx
+++ b/src/views/my-catalog/AddEditSpec.tsx
@@ -23,6 +23,7 @@ import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
 import FormGroup from "react-bootstrap/FormGroup";
 import {colors} from "../../App";
+import {newSpec} from "../../common/services/userapps.service";
 
 const sortBy = (s1: V1.Service, s2: V1.Service) => {
     const sid1 = s1.label+"";
@@ -49,40 +50,7 @@ const AddEditSpecPage = (props: any) => {
     /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
     const [stacks, setStacks] = useState<Array<V1.Stack>>([]);
     const [specs, setSpecs] = useState<Array<V1.Service>>([]);
-    const [spec, setSpec] = useState<V1.Service>({
-        // Basic Info
-        key: '',
-        label: '',
-
-        // Access Info
-        display: 'stack',
-        access: 'external',
-
-        // Docker info
-        image: {
-            name: '',
-            tags: ['latest']
-        },
-
-        // Help Info
-        logo: '',
-        info: '',
-
-        // Tabbed info
-        depends: [],
-        config: [],
-        ports: [],
-        volumeMounts: [],
-
-        // TODO: no UI for these yet (advanced features)
-        additionalResources: [],
-        developerEnvironment: undefined,
-        repositories: [],
-        command: [],
-        args: [],
-        catalog: 'user',
-        tags: []
-    });
+    const [spec, setSpec] = useState<V1.Service>(newSpec());
 
     // User selection
     const [selectedTab, setSelectedTab] = useState('BasicInfo');

--- a/src/views/my-catalog/AddEditSpec.tsx
+++ b/src/views/my-catalog/AddEditSpec.tsx
@@ -287,10 +287,32 @@ const AddEditSpecPage = (props: any) => {
         setRedirect('/my-catalog');
     }
 
+    const getError = (spec: V1.Service): string => {
+        if (!spec?.key) {
+            console.error('Error: you must assign a unique key to this service to save it');
+            return '"key" is required';
+        }
+
+        if (!spec?.image.name) {
+            console.error('Error: you must assign a Docker image name to run for this app');
+            return '"image.name" is required';
+        }
+
+        return '';
+    }
+
+    const isValid = (spec: V1.Service): boolean => {
+        return getError(spec) === '';
+    }
+
     const saveSpec = (spec: V1.Service) => {
         if (spec.catalog === 'system' && !user?.groups?.includes('/workbench-admin')) {
             // User is not an admin
             return;
+        }
+
+        if (!spec.image.tags?.length) {
+            spec.image.tags = ['latest'];
         }
 
         if (!spec || !spec.key) { return; }
@@ -336,11 +358,12 @@ const AddEditSpecPage = (props: any) => {
                     <h2>{specKey ? 'Edit Application: ' + specKey : 'Create New Application'}</h2>
                 </Col>
                 <Col className={'text-align-right'}>
-                    <Button className={'btn-lg btn-secondary'} onClick={() => cancelSave(spec)}>
-                        <FontAwesomeIcon icon={faTimes} /> Cancel
-                    </Button>
-                    <Button disabled={!spec.key || !spec.image.name || !(spec.image.tags.length && spec.image.tags[0])} className={'btn-lg btn-success'} onClick={() => saveSpec(spec)}>
+                    <span style={{ color: 'red' }}>{getError(spec)}</span>
+                    <Button disabled={!isValid(spec)} className={'btn-lg btn-success pull-right m-10'} onClick={() => saveSpec(spec)}>
                         <FontAwesomeIcon icon={faSave} /> Save
+                    </Button>
+                    <Button className={'btn-lg btn-secondary pull-right m-10'} onClick={() => cancelSave(spec)}>
+                        <FontAwesomeIcon icon={faTimes} /> Cancel
                     </Button>
                 </Col>
             </Row>

--- a/src/views/my-catalog/MyCatalog.css
+++ b/src/views/my-catalog/MyCatalog.css
@@ -5,4 +5,6 @@
 .text-align-right {
     text-align: right;
 }
-
+.m-10 {
+    margin: 10px;
+}

--- a/src/views/my-catalog/MyCatalog.tsx
+++ b/src/views/my-catalog/MyCatalog.tsx
@@ -90,12 +90,12 @@ const MyCatalogPage = (props: any) => {
                     action: 'clone',
                     label: appSpec.key
                 });
-                props.specs.push(appSpec);
+                specs.push(appSpec);
                 setRedirect('/my-catalog/'+specCopy.key);
             }).catch(reason => {
                 if (CONFLICT_409(reason)) {
                     // Copy of this spec already exists, redirect to catalog to see it
-                    setRedirect(`/my-catalog`);
+                    setRedirect(`/my-catalog/${specCopy.key}`);
                 } else {
                     handleError(`Failed to clone ${specCopy.key} app spec`, reason)
                 }
@@ -143,7 +143,7 @@ const MyCatalogPage = (props: any) => {
             }
             <div style={{ height: "10vh" }}></div>
             <h2 className={'marginTop pull-left'}>My Catalog</h2>
-            <Button className={'btn-secondary btn-lg pull-right m-10'} onClick={createSpec}>
+            <Button className={'btn-success btn-lg pull-right m-10'} onClick={createSpec}>
                 <FontAwesomeIcon icon={faPlus} /> Create New Application
             </Button>
             <Button className={'btn-secondary btn-lg pull-right m-10'} onClick={importSpec}>
@@ -207,6 +207,7 @@ const MyCatalogPage = (props: any) => {
 
             <ImportExportSpecDialog spec={selectedSpec}
                                     show={showImportExportSpec}
+                                    height={'70vh'}
                                     onClose={() => setShowImportExportSpec(false)}
                                     setRedirect={setRedirect}></ImportExportSpecDialog>
 


### PR DESCRIPTION
## Problem
Errors encountered during clone/copy/edit

No way to quickly share specs with other users

## Approach
* Consolidate `cloneSpec` into a shared helper function
* Added Import / Export spec dialog - allows users to quickly share a working spec with one another
* Added validation messages for Import/Export spec and Add/Edit spec

## How to Test
Test Setup:
1. From workbench-helm-chart, run `make dev`
2. `cd src/webui/ && git fetch --all && git checkout my-catalog-bugfixes-import-export-spec` to checkout this branch locally

Import Spec:
1. From the MyCatalog page, click Import spec at the top-right
    * You should see the ImportExportSpecDialog open (in "Import" mode)
    * You should see a basic spec skeleton is provided here
2. Click on Import
    * You should see a validation message pop up here saying: `"key" is required`
3. Enter a values for `key` and click Import again
    * You should see a new validation message appear: `"image.name" is required`
4. Enter a unique value for `image.name` and click Import one more time
    * You should see the new spec is created
    * You should be redirected to the AddEditSpec page for this new spec

Validation:
1. From Add/Edit Spec, you should immediately see the validation messages
    * e.g. `"key" is required`, `"image.name" is required`, etc

Export Spec:
1. From the MyCatalog page, click Import spec at the top-right
    * You should see the ImportExportSpecDialog open (in "Import" mode)
    * You should see a button to copy the spec to your clipboard
2. Click "Copy to Clipboard"
3. Paste the spec into your address bar, or share it with someone else so they can import it :D
 