### PR TITLE
fix: check for workbench-dev role in addition to group

### DIFF
--- a/src/views/my-apps/MyApps.tsx
+++ b/src/views/my-apps/MyApps.tsx
@@ -289,7 +289,7 @@ function MyAppsPage(props: any) {
                                     <Col xs={3} style={{ textAlign: "right", marginTop: "10px" }}>
                                         <Button variant="link" onClick={() => confirmDelete(stack)} style={{ color: darkThemeEnabled && stack.status === 'stopped' ? 'white' : 'black' }} title={'Remove application (' + stack.id + ')'}><FontAwesomeIcon icon={faTrash} /></Button>
                                         {
-                                            user?.groups?.includes('/workbench-developers') && <Button variant="link" onClick={() => editStack(stack)}
+                                            (user?.groups?.includes('role:workbench-dev') || user?.groups?.includes('/workbench-developers')) && <Button variant="link" onClick={() => editStack(stack)}
                                                     style={{color: darkThemeEnabled && stack.status === 'stopped' ? 'white' : 'black'}}
                                                     title={'Edit application (' + stack.id + ')'}><FontAwesomeIcon
                                                 icon={faEdit}/></Button>


### PR DESCRIPTION
## Problem
Sometimes Keycloak Groups aren't mapped properly?

Unclear if this is due to configuration error, or something else

## Approach
* fix: fallback to checking Role name (in addition to group name)

## How to Test
1. Checkout and run this branch locally (see [workbench-helm-chart](https://github.com/nds-org/workbench-helm-chart))
2. Navigate to https://kubernetes.docker.internal/ (ignore browser certificate warnings)
3. Login/register with Keycloak
    * You should be brought back to the Workbench, now logged in
4. Edit your user in Keycloak to have the `workbench-dev` role (optionally, without the group)
5. Add an application from the "All Apps"
    * You should be brought to "My Apps" to see your new app
    * You should see an "Edit" (pencil) icon beside the Launch button
6. Click the Edit button
    * You should see the "Edit Service" page loads
    * You should see this offers you a way to set custom envvars for the application